### PR TITLE
Fix: Teleport entities synchronously & null check for shop inventories

### DIFF
--- a/core/src/main/java/me/deadlight/ezchestshop/guis/AdminShopGUI.java
+++ b/core/src/main/java/me/deadlight/ezchestshop/guis/AdminShopGUI.java
@@ -187,6 +187,11 @@ public class AdminShopGUI {
                 }
 
                 Inventory lastinv = Utils.getBlockInventory(theBlock);
+                if (lastinv == null) {
+                    player.closeInventory();
+                    return;
+                }
+
                 if (lastinv instanceof DoubleChestInventory) {
                     DoubleChest doubleChest = (DoubleChest) lastinv.getHolder(false);
                     lastinv = doubleChest.getInventory();

--- a/core/src/main/java/me/deadlight/ezchestshop/guis/OwnerShopGUI.java
+++ b/core/src/main/java/me/deadlight/ezchestshop/guis/OwnerShopGUI.java
@@ -186,6 +186,11 @@ public class OwnerShopGUI {
                 }
 
                 Inventory lastinv = Utils.getBlockInventory(theBlock);
+                if (lastinv == null) {
+                    player.closeInventory();
+                    return;
+                }
+
                 if (lastinv instanceof DoubleChestInventory) {
                     DoubleChest doubleChest = (DoubleChest) lastinv.getHolder(false);
                     lastinv = doubleChest.getInventory();

--- a/core/src/main/java/me/deadlight/ezchestshop/utils/ASHologram.java
+++ b/core/src/main/java/me/deadlight/ezchestshop/utils/ASHologram.java
@@ -2,6 +2,7 @@ package me.deadlight.ezchestshop.utils;
 
 import java.util.concurrent.ThreadLocalRandom;
 
+import me.deadlight.ezchestshop.EzChestShop;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
 
@@ -34,8 +35,10 @@ public class ASHologram {
     }
 
     public void teleport(Location location) {
-        this.location = location;
-        Utils.nmsHandle.teleportEntity(handler, entityID, location);
+        Bukkit.getScheduler().runTask(EzChestShop.getPlugin(), () -> {
+            this.location = location;
+            Utils.nmsHandle.teleportEntity(handler, entityID, location);
+        });
     }
 
     public void rename(String name) {

--- a/core/src/main/java/me/deadlight/ezchestshop/utils/ASHologram.java
+++ b/core/src/main/java/me/deadlight/ezchestshop/utils/ASHologram.java
@@ -5,7 +5,6 @@ import java.util.concurrent.ThreadLocalRandom;
 import me.deadlight.ezchestshop.EzChestShop;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
-import org.bukkit.Bukkit;
 
 public class ASHologram {
 
@@ -35,7 +34,8 @@ public class ASHologram {
     }
 
     public void teleport(Location location) {
-        Bukkit.getScheduler().runTask(EzChestShop.getPlugin(), () -> {
+        // May be worth to investigate the caller here
+        EzChestShop.getScheduler().runTask(() -> {
             this.location = location;
             Utils.nmsHandle.teleportEntity(handler, entityID, location);
         });

--- a/core/src/main/java/me/deadlight/ezchestshop/utils/ASHologram.java
+++ b/core/src/main/java/me/deadlight/ezchestshop/utils/ASHologram.java
@@ -5,7 +5,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import me.deadlight.ezchestshop.EzChestShop;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
-
+import org.bukkit.Bukkit;
 
 public class ASHologram {
 


### PR DESCRIPTION
This fixes the following errors:
`[17:55:00] [Server thread/WARN]: Illegal Entity Teleport ItemEntity['Steak'/1601764467, uuid='eb2c3d03-553d-498d-90b1-771e107cc678', l='ServerLevel[world]', x=-11015.70, y=70.05, z=-6486.00, cpos=[-689, -406], tl=0, v=false] to ServerLevel[PVPARENA]:(-11015.7, 70.05000000000001, -6486.0)
java.lang.Throwable: null`

and

`java.lang.NullPointerException: Cannot invoke "org.bukkit.inventory.Inventory.getSize()" because "shopInventory" is null`