### PR TITLE
Revert & Fix: Sync teleporting of holograms

### DIFF
--- a/core/src/main/java/me/deadlight/ezchestshop/utils/ASHologram.java
+++ b/core/src/main/java/me/deadlight/ezchestshop/utils/ASHologram.java
@@ -2,7 +2,6 @@ package me.deadlight.ezchestshop.utils;
 
 import java.util.concurrent.ThreadLocalRandom;
 
-import me.deadlight.ezchestshop.EzChestShop;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
 
@@ -34,11 +33,8 @@ public class ASHologram {
     }
 
     public void teleport(Location location) {
-        // May be worth to investigate the caller here
-        EzChestShop.getScheduler().runTask(() -> {
-            this.location = location;
-            Utils.nmsHandle.teleportEntity(handler, entityID, location);
-        });
+        this.location = location;
+        Utils.nmsHandle.teleportEntity(handler, entityID, location);
     }
 
     public void rename(String name) {


### PR DESCRIPTION
Reverting this fixes the positioning of holograms.

Before (below)
![image](https://github.com/user-attachments/assets/63e1454f-6967-46b6-8c62-3d376ca9d6da)
